### PR TITLE
feat: 사이드바 한 쪽으로 통일 후 탭 메뉴 추가

### DIFF
--- a/src/pages/Main/Sidebar/BackgroundSidebar/index.scss
+++ b/src/pages/Main/Sidebar/BackgroundSidebar/index.scss
@@ -1,22 +1,5 @@
 @import '~/styles/variables';
 
-.container {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-
-  width: 20%;
-  min-width: 400px;
-  height: 100%;
-  min-height: 100vh;
-
-  padding: 2rem;
-  box-sizing: border-box;
-
-  background-color: $GRAY_001;
-  color: $WHITE_000;
-}
-
 .BackgroundControlContainer {
   display: flex;
   flex-direction: column;
@@ -57,20 +40,6 @@
   }
 }
 
-.submitButtonContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-
-  margin-top: 1rem;
-
-  & > button {
-    height: 2.5rem;
-
-    border-radius: 5px;
-  }
-}
-
 .buttonWrapper {
   display: flex;
   flex-direction: column;
@@ -84,7 +53,6 @@
     border-right: 1px solid $GRAY_ALPHA_000;
   }
 }
-
 .selected {
   background-color: $GREEN_002;
 
@@ -102,14 +70,6 @@
 .lastButton {
   border-radius: 0 5px 5px 0;
   border: none;
-}
-
-.submitButton {
-  background-color: $GREEN_000;
-
-  &:hover {
-    background-color: $GREEN_001;
-  }
 }
 
 .imageInButton {

--- a/src/pages/Main/Sidebar/BackgroundSidebar/index.tsx
+++ b/src/pages/Main/Sidebar/BackgroundSidebar/index.tsx
@@ -15,18 +15,12 @@ function BackgroundSidebar() {
     backgroundType,
     backgroundFilter,
     setBackgroundFilter,
-    saveCurrentConfiguration,
-    loadLatestConfiguration,
   } = useThumbnailData();
   const modalObject = useContext(ModalContext);
 
   if (isLoading || !modalObject) return <></>;
 
-  const {
-    showBackgroundColorModal,
-    showBackgroundImageModal,
-    showCreateThumbnailModal,
-  } = modalObject;
+  const { showBackgroundColorModal, showBackgroundImageModal } = modalObject;
 
   const changeImageSize = (newSize: ThumbnailData['imageSize']) => {
     setImageSize(newSize);
@@ -43,13 +37,8 @@ function BackgroundSidebar() {
     setBackgroundFilter(newType);
   };
 
-  const generateThumbnail = () => {
-    saveCurrentConfiguration();
-    showCreateThumbnailModal();
-  };
-
   return (
-    <div className={styles.container}>
+    <>
       <div className={styles.BackgroundControlContainer}>
         <h3>파일 사이즈 선택</h3>
         <div className={styles.buttonContainer}>
@@ -119,13 +108,7 @@ function BackgroundSidebar() {
           </button>
         </div>
       </div>
-      <div className={styles.submitButtonContainer}>
-        <button onClick={loadLatestConfiguration}>최근 설정 불러오기</button>
-        <button className={styles.submitButton} onClick={generateThumbnail}>
-          썸네일 생성
-        </button>
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/src/pages/Main/Sidebar/TextSidebar/index.scss
+++ b/src/pages/Main/Sidebar/TextSidebar/index.scss
@@ -1,26 +1,9 @@
 @import '~/styles/variables';
 
-.container {
+.TextControlContainer {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-
-  width: 20%;
-  min-width: 400px;
-  height: 100%;
-  min-height: 100vh;
-
-  padding: 2rem;
-  box-sizing: border-box;
-
-  background-color: $GRAY_001;
-  color: $WHITE_000;
-
-  h2 {
-    font-size: 1.25rem;
-
-    margin-bottom: 1rem;
-  }
+  gap: 2rem;
 }
 
 .buttonContainer {

--- a/src/pages/Main/Sidebar/TextSidebar/index.tsx
+++ b/src/pages/Main/Sidebar/TextSidebar/index.tsx
@@ -6,6 +6,11 @@ import styles from './index.scss';
 function TextSidebar() {
   const {
     isLoading,
+    title,
+    subtitle,
+    fontSize,
+    fontFamily,
+    fontColor,
     setTitle,
     setSubtitle,
     setFontSize,
@@ -48,66 +53,74 @@ function TextSidebar() {
   };
 
   return (
-    <div className={styles.container}>
-      <h2>텍스트 설정</h2>
-      <div className={styles.titleContainer}>
-        <h3>제목</h3>
-        <input
-          id="title"
-          type="text"
-          name="title"
-          onChange={changeTitle}
-          placeholder="썸네일 제목"
-        />
+    <>
+      <div className={styles.TextControlContainer}>
+        <div className={styles.titleContainer}>
+          <h3>제목</h3>
+          <input
+            id="title"
+            type="text"
+            name="title"
+            value={title}
+            onChange={changeTitle}
+            placeholder="썸네일 제목"
+          />
+        </div>
+        <div className={styles.titleContainer}>
+          <h3>소제목</h3>
+          <input
+            id="subtitle"
+            type="text"
+            name="subtitle"
+            value={subtitle}
+            onChange={changeSubtitle}
+            placeholder="썸네일 소제목"
+          />
+        </div>
+        <div className={styles.singleInputContainer}>
+          <label htmlFor="font_family">폰트 스타일</label>
+          <select
+            name="font_family"
+            value={fontFamily}
+            onChange={changeFontFamily}
+          >
+            <option value="나눔고딕체">나눔고딕체</option>
+            <option value="도현체">도현체</option>
+            <option value="원스토어모바일POP체">원스토어모바일POP체</option>
+          </select>
+        </div>
+        <div className={styles.singleInputContainer}>
+          <label htmlFor="font_size">글자 크기</label>
+          <select name="font_size" value={fontSize} onChange={changeFontSize}>
+            <option value="Small">작음</option>
+            <option value="Normal">보통</option>
+            <option value="Big">큼</option>
+          </select>
+        </div>
+        <div className={styles.singleInputContainer}>
+          <label htmlFor="font_color">글자 색</label>
+          <input
+            id="font_color"
+            type="color"
+            name="font_color"
+            value={fontColor}
+            onChange={changeFontColor}
+            placeholder=""
+          />
+        </div>
+        <div className={styles.singleInputContainer}>
+          <label htmlFor="font_shadow">그림자 효과</label>
+          <input
+            id="font_shadow"
+            type="checkbox"
+            name="font_shadow"
+            value="font_shadow"
+            checked={hasFontShadow}
+            onChange={changeHasFontShadow}
+          />
+        </div>
       </div>
-      <div className={styles.titleContainer}>
-        <h3>소제목</h3>
-        <input
-          id="subtitle"
-          type="text"
-          name="subtitle"
-          onChange={changeSubtitle}
-          placeholder="썸네일 소제목"
-        />
-      </div>
-      <div className={styles.singleInputContainer}>
-        <label htmlFor="font_family">폰트 스타일</label>
-        <select name="font_family" onChange={changeFontFamily}>
-          <option value="나눔고딕체">나눔고딕체</option>
-          <option value="도현체">도현체</option>
-          <option value="원스토어모바일POP체">원스토어모바일POP체</option>
-        </select>
-      </div>
-      <div className={styles.singleInputContainer}>
-        <label htmlFor="font_size">글자 크기</label>
-        <select name="font_size" onChange={changeFontSize}>
-          <option value="Small">작음</option>
-          <option value="Normal">보통</option>
-          <option value="Big">큼</option>
-        </select>
-      </div>
-      <div className={styles.singleInputContainer}>
-        <label htmlFor="font_color">글자 색</label>
-        <input
-          id="font_color"
-          type="color"
-          name="font_color"
-          onChange={changeFontColor}
-          placeholder=""
-        />
-      </div>
-      <div className={styles.singleInputContainer}>
-        <label htmlFor="font_shadow">그림자 효과</label>
-        <input
-          id="font_shadow"
-          type="checkbox"
-          name="font_shadow"
-          value="font_shadow"
-          checked={hasFontShadow}
-          onChange={changeHasFontShadow}
-        />
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/src/pages/Main/Sidebar/index.scss
+++ b/src/pages/Main/Sidebar/index.scss
@@ -1,0 +1,82 @@
+@import '~/styles/variables';
+
+.container {
+  display: flex;
+  flex-direction: column;
+
+  width: 20%;
+  min-width: 400px;
+  height: 100%;
+  min-height: 90vh;
+
+  background-color: $GRAY_001;
+  color: $WHITE_000;
+}
+
+.tabMenu {
+  display: flex;
+
+  width: 100%;
+  min-height: 50px;
+
+  button {
+    width: 50%;
+
+    font-size: 1rem;
+    font-weight: bold;
+
+    background-color: $GRAY_005;
+  }
+
+  .selected {
+    background-color: $GRAY_001;
+  }
+}
+
+.propertyContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 100%;
+  height: 85vh;
+
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.submitButtonContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  margin-top: 1rem;
+
+  & > button {
+    height: 2.5rem;
+
+    border-radius: 5px;
+  }
+}
+
+.buttonWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+
+  button {
+    width: 10rem;
+    height: 5rem;
+
+    border-right: 1px solid $GRAY_ALPHA_000;
+  }
+}
+
+.submitButton {
+  background-color: $GREEN_000;
+
+  &:hover {
+    background-color: $GREEN_001;
+  }
+}

--- a/src/pages/Main/Sidebar/index.tsx
+++ b/src/pages/Main/Sidebar/index.tsx
@@ -1,0 +1,54 @@
+import { useContext, useState } from 'react';
+import BackgroundSidebar from './BackgroundSidebar';
+import TextSidebar from './TextSidebar';
+import useThumbnailData from 'hooks/useThumbnailData';
+import { ModalContext } from 'stores/modalContext';
+import styles from './index.scss';
+
+type ActiveTabType = 'layout' | 'text';
+
+function Sidebar() {
+  const { isLoading, saveCurrentConfiguration, loadLatestConfiguration } =
+    useThumbnailData();
+  const modalObject = useContext(ModalContext);
+  const [activeTab, setActiveTab] = useState<ActiveTabType>('layout');
+
+  if (isLoading || !modalObject) return <></>;
+
+  const { showCreateThumbnailModal } = modalObject;
+
+  const generateThumbnail = () => {
+    saveCurrentConfiguration();
+    showCreateThumbnailModal();
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.tabMenu}>
+        <button
+          className={`${activeTab === 'layout' ? styles.selected : ''}`}
+          onClick={() => setActiveTab('layout')}
+        >
+          레이아웃
+        </button>
+        <button
+          className={`${activeTab === 'text' ? styles.selected : ''}`}
+          onClick={() => setActiveTab('text')}
+        >
+          텍스트
+        </button>
+      </div>
+      <div className={styles.propertyContainer}>
+        {activeTab === 'layout' ? <BackgroundSidebar /> : <TextSidebar />}
+        <div className={styles.submitButtonContainer}>
+          <button onClick={loadLatestConfiguration}>최근 설정 불러오기</button>
+          <button className={styles.submitButton} onClick={generateThumbnail}>
+            썸네일 생성
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Sidebar;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -2,6 +2,7 @@ import useThumbnail from 'hooks/useThumbnail';
 import useAppState from 'hooks/useAppState';
 import useModal from 'hooks/useModal';
 import Preview from './Preview';
+import Sidebar from './Sidebar';
 import BackgroundSidebar from './Sidebar/BackgroundSidebar';
 import TextSidebar from './Sidebar/TextSidebar';
 import BackgroundColor from 'components/BackgroundColor';
@@ -20,9 +21,8 @@ function Main() {
       <ModalContext.Provider value={useModal()}>
         <ThumbnailContext.Provider value={useThumbnail()}>
           <AppStateContext.Provider value={useAppState()}>
-            <BackgroundSidebar />
+            <Sidebar />
             <Preview />
-            <TextSidebar />
             <BackgroundColor />
             <BackgroundImage />
             <CreateThumbnail />
@@ -34,5 +34,4 @@ function Main() {
     </div>
   );
 }
-
 export default Main;


### PR DESCRIPTION
## 변경된 점

**1. 사이드바 배치 변경**
- 탭 메뉴 방식으로 변경
- 사이드바 별 css 통일

### 기존
![image](https://github.com/usageness/thumbnail-Generator/assets/28296575/59894498-2108-4fed-8116-739f7bcccb4b)

### 변경 후
![image](https://github.com/usageness/thumbnail-Generator/assets/28296575/803152b2-8126-4980-b6db-e827aaf649c0)

**2. 버그 수정**
- 저장된 데이터 불러오기 후 입력창에 반영되지 않던 버그 수정